### PR TITLE
ENGOPS-3608 Update Docker File with jdk11 installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,10 @@ RUN curl -SL --output dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$
 	&& rm dotnet.tar.gz \
 	&& ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet
 
+RUN sed 's+$JAVA_BIN $JAVA_OPTS+/usr/lib/jvm/openjdk-11.0.16_8/bin/java $JAVA_OPTS+g' /usr/local/bin/jenkins-agent > /usr/local/bin/jenkins-agent-java11
+
+RUN chmod +x /usr/local/bin/jenkins-agent-java11
+
 USER jenkins
 
 RUN dotnet tool install --global dotnet-sonarscanner


### PR DESCRIPTION
So we are trying to upgrade jenkins from Jenkins 2.332.3 to Jenkins 2.387.1.
The default Jenkins version works on Java 8 and newer version requires Java 11 or 17. So in order to make our ecs agents working in the new environment,we decided to update docker files by creating a new executable /usr/local/bin/jenkins-agent-java11 on the agent image, which we plugged into ENTRYPOINT OVERRIDE in the Jenkins config, to make the image support both Java 8 (current) Jenkins and Java 11 (upgraded) Jenkins.